### PR TITLE
Fix undefined command

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ proxy server (see below)
 npm install live-server
 ```
 
-Now run `./start-proxy <folder>`. For example, to run the filemanager:
+Now run `./start-proxy.js <folder>`. For example, to run the filemanager:
 
 ```shell
-./start-proxy ./examples/filemanager
+./start-proxy.js ./examples/filemanager
 ```
 


### PR DESCRIPTION
I updated README file. `start-proxy` command wasn't exist.